### PR TITLE
feat: add Google Analytics tracking

### DIFF
--- a/core/templates/base.html
+++ b/core/templates/base.html
@@ -1,25 +1,41 @@
 <!DOCTYPE html>
 <html lang="es">
-  <head>
-    <title>{% block title %}Transbank Sdk Python Example{% endblock %}</title>
-    <meta name="viewport" content="width=device-width,initial-scale=1" />
-    <meta name="apple-mobile-web-app-capable" content="yes" />
-    <meta name="mobile-web-app-capable" content="yes" />
+    <head>
+        <title>
+            {% block title %}Transbank Sdk Python Example{% endblock %}
+        </title>
+        <meta name="viewport" content="width=device-width,initial-scale=1" />
+        <meta name="apple-mobile-web-app-capable" content="yes" />
+        <meta name="mobile-web-app-capable" content="yes" />
 
-    {% block head %}{% endblock %} {% load static %}
-    <link rel="icon" href="{% static 'icon.png' %}" type="image/png" />
-    <link rel="icon" href="{% static 'icon.svg' %}" type="image/svg+xml" />
-    <link rel="apple-touch-icon" href="{% static 'icon.png' %}" />
+        <!-- Google tag (gtag.js) -->
+        <script
+            async
+            src="https://www.googletagmanager.com/gtag/js?id=G-02BDNS38Y1"
+        ></script>
+        <script>
+            window.dataLayer = window.dataLayer || [];
+            function gtag() {
+                dataLayer.push(arguments);
+            }
+            gtag("js", new Date());
 
-    <link rel="stylesheet" href="{% static 'css/styles.css' %}" />
+            gtag("config", "G-02BDNS38Y1");
+        </script>
 
-    <script src="{% static 'js/menu_controller.js' %}"></script>
-  </head>
-  <body>
-    <div class="layout-home">
-      {% include 'partials/header.html' %} 
-      {% block content %}{% endblock %} 
-      {% include 'partials/footer.html' %}
-    </div>
-  </body>
+        {% block head %}{% endblock %} {% load static %}
+        <link rel="icon" href="{% static 'icon.png' %}" type="image/png" />
+        <link rel="icon" href="{% static 'icon.svg' %}" type="image/svg+xml" />
+        <link rel="apple-touch-icon" href="{% static 'icon.png' %}" />
+
+        <link rel="stylesheet" href="{% static 'css/styles.css' %}" />
+
+        <script src="{% static 'js/menu_controller.js' %}"></script>
+    </head>
+    <body>
+        <div class="layout-home">
+            {% include 'partials/header.html' %} {% block content %}{% endblock
+            %} {% include 'partials/footer.html' %}
+        </div>
+    </body>
 </html>

--- a/core/templates/layout.html
+++ b/core/templates/layout.html
@@ -1,40 +1,59 @@
 <!DOCTYPE html>
 <html lang="es">
-  <head>
-    <title>{% block title %}Transbank Sdk Python Example{% endblock %}</title>
-    <meta name="viewport" content="width=device-width,initial-scale=1" />
-    <meta name="apple-mobile-web-app-capable" content="yes" />
-    <meta name="mobile-web-app-capable" content="yes" />
+    <head>
+        <title>
+            {% block title %}Transbank Sdk Python Example{% endblock %}
+        </title>
+        <meta name="viewport" content="width=device-width,initial-scale=1" />
+        <meta name="apple-mobile-web-app-capable" content="yes" />
+        <meta name="mobile-web-app-capable" content="yes" />
 
-    {% block head %}{% endblock %} {% load static %}
-    <link rel="icon" href="{% static 'icon.png' %}" type="image/png" />
-    <link rel="icon" href="{% static 'icon.svg' %}" type="image/svg+xml" />
-    <link rel="apple-touch-icon" href="{% static 'icon.png' %}" />
+        <!-- Google tag (gtag.js) -->
+        <script
+            async
+            src="https://www.googletagmanager.com/gtag/js?id=G-02BDNS38Y1"
+        ></script>
+        <script>
+            window.dataLayer = window.dataLayer || [];
+            function gtag() {
+                dataLayer.push(arguments);
+            }
+            gtag("js", new Date());
 
-    <link rel="stylesheet" href="{% static 'css/styles.css' %}" />
-    <link rel="stylesheet" href="{% static 'css/pygments-monokai.css' %}" />
+            gtag("config", "G-02BDNS38Y1");
+        </script>
 
-    <script src="{% static 'js/menu_controller.js' %}"></script>
-  </head>
-  <body>
-    <div class="main-container">
-      {% include 'partials/header.html' %} 
-      <div class="body-container {% if not navigation %} no-nav{% endif %}">
-					{% include 'partials/sidebar.html' %}
-          <div class="body-content ">
-            {% block content %}{% endblock %} 
-            {% include 'partials/channels.html' %}
-          </div>
-					{% if navigation%}
-						<div class="helper-content">    
-							{% include 'partials/navigation.html' %}
-						</div>
-					{% endif %}
-      </div>
-      {% include 'partials/footer.html' %}
-    </div>
+        {% block head %}{% endblock %} {% load static %}
+        <link rel="icon" href="{% static 'icon.png' %}" type="image/png" />
+        <link rel="icon" href="{% static 'icon.svg' %}" type="image/svg+xml" />
+        <link rel="apple-touch-icon" href="{% static 'icon.png' %}" />
 
-    <script src="{% static 'js/sidebar.js' %}"></script>
-    <script src="{% static 'js/navigation.js' %}"></script>
-  </body>
+        <link rel="stylesheet" href="{% static 'css/styles.css' %}" />
+        <link rel="stylesheet" href="{% static 'css/pygments-monokai.css' %}" />
+
+        <script src="{% static 'js/menu_controller.js' %}"></script>
+    </head>
+    <body>
+        <div class="main-container">
+            {% include 'partials/header.html' %}
+            <div
+                class="body-container {% if not navigation %} no-nav{% endif %}"
+            >
+                {% include 'partials/sidebar.html' %}
+                <div class="body-content">
+                    {% block content %}{% endblock %} {% include
+                    'partials/channels.html' %}
+                </div>
+                {% if navigation%}
+                <div class="helper-content">
+                    {% include 'partials/navigation.html' %}
+                </div>
+                {% endif %}
+            </div>
+            {% include 'partials/footer.html' %}
+        </div>
+
+        <script src="{% static 'js/sidebar.js' %}"></script>
+        <script src="{% static 'js/navigation.js' %}"></script>
+    </body>
 </html>


### PR DESCRIPTION
This PR includes the Google Analytics script in the base HTML templates, enabling data collection for analysis and reporting. Consider most of the registered changes are just formatter adjustments made by my extesion "Prettier", so the relevant segments to check are the ones commented with "Google tag (gtag.js)".

## Test
Communications with the gtag are stablished since the first access to the page (check the gtag and google-analytics on network activity)

<img width="1807" height="1071" alt="Captura de pantalla 2025-09-11 a las 16 35 36" src="https://github.com/user-attachments/assets/d17af34e-dab3-470f-a54d-d0bc488a42d5" />
